### PR TITLE
Add bindings for MouseEvent.movement*

### DIFF
--- a/src/Web/UIEvent/MouseEvent.js
+++ b/src/Web/UIEvent/MouseEvent.js
@@ -24,6 +24,14 @@ exports.pageY = function (e) {
   return e.pageY;
 };
 
+exports.movementX = function (e) {
+  return e.movementX;
+};
+
+exports.movementY = function (e) {
+  return e.movementY;
+};
+
 exports.ctrlKey = function (e) {
   return e.ctrlKey;
 };

--- a/src/Web/UIEvent/MouseEvent.purs
+++ b/src/Web/UIEvent/MouseEvent.purs
@@ -10,6 +10,8 @@ module Web.UIEvent.MouseEvent
   , clientY
   , pageX
   , pageY
+  , movementX
+  , movementY
   , ctrlKey
   , shiftKey
   , altKey
@@ -56,6 +58,10 @@ foreign import clientY :: MouseEvent -> Int
 foreign import pageX :: MouseEvent -> Int
 
 foreign import pageY :: MouseEvent -> Int
+
+foreign import movementX :: MouseEvent -> Int
+
+foreign import movementY :: MouseEvent -> Int
 
 foreign import ctrlKey :: MouseEvent -> Boolean
 


### PR DESCRIPTION
I've just seen from #2 that you're unlikely to merge this since `movementX` and `movementY` are not in the spec. But [they are very widely-implemented, and may some day be standardized](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/movementX), so I'll put this here for posterity.