### PR TITLE
Add auxclick to MouseEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ New features:
 Bugfixes:
 
 Other improvements:
-- Add auxclick to MouseEvent (#18)
+- Add auxclick to MouseEvent (#18 by @joe-op)
 
 ## [v3.0.0](https://github.com/purescript-web/purescript-web-uievents/releases/tag/v3.0.0) - 2021-02-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Add auxclick to MouseEvent (#18)
 
 ## [v3.0.0](https://github.com/purescript-web/purescript-web-uievents/releases/tag/v3.0.0) - 2021-02-26
 

--- a/src/Web/UIEvent/MouseEvent/EventTypes.purs
+++ b/src/Web/UIEvent/MouseEvent/EventTypes.purs
@@ -2,6 +2,9 @@ module Web.UIEvent.MouseEvent.EventTypes where
 
 import Web.Event.Event (EventType(..))
 
+auxclick :: EventType
+auxclick = EventType "auxclick"
+
 click :: EventType
 click = EventType "click"
 


### PR DESCRIPTION
**Description of the change**

Adds auxclick to MouseEvent (#18) for middle click/ ctrl+click.
---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
