### PR TITLE
Add null support for data property of InputEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Notable changes to this project are documented in this file. The format is based
 ## [Unreleased]
 
 Breaking changes:
-- Add null support for `data` property of `InputEvent` 
+- Add null support for `data` property of `InputEvent` (#21)
 
 New features:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Notable changes to this project are documented in this file. The format is based
 ## [Unreleased]
 
 Breaking changes:
+- Add null support for `data` property of `InputEvent` 
 
 New features:
 

--- a/src/Web/UIEvent/InputEvent.js
+++ b/src/Web/UIEvent/InputEvent.js
@@ -1,4 +1,4 @@
-export function data_(e) {
+export function _data_(e) {
   return e.data;
 }
 

--- a/src/Web/UIEvent/InputEvent.purs
+++ b/src/Web/UIEvent/InputEvent.purs
@@ -1,6 +1,17 @@
-module Web.UIEvent.InputEvent where
+module Web.UIEvent.InputEvent
+  ( InputEvent
+  , data_
+  , fromEvent
+  , fromUIEvent
+  , isComposing
+  , toEvent
+  , toUIEvent
+  ) where
+
+import Prelude
 
 import Data.Maybe (Maybe)
+import Data.Nullable (Nullable, toMaybe)
 import Unsafe.Coerce (unsafeCoerce)
 import Web.Event.Event (Event)
 import Web.Internal.FFI (unsafeReadProtoTagged)
@@ -20,6 +31,9 @@ toUIEvent = unsafeCoerce
 toEvent :: InputEvent -> Event
 toEvent = unsafeCoerce
 
-foreign import data_ :: InputEvent -> String
+foreign import _data_ :: InputEvent -> Nullable String
+
+data_ :: InputEvent -> Maybe String
+data_ = toMaybe <$> _data_
 
 foreign import isComposing :: InputEvent -> Boolean


### PR DESCRIPTION
**Description of the change**

Change `InputEvent` `data_` FFI import to private `_data_` function returning type `Nullable String` to accommodate null `data` property. Export `data_` function, now returning type `Maybe String`.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
