### PR TITLE
Add inputType for InputEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
+- Add support for inputType on InputEvents (#23 by @MonaMayrhofer)
 
 Bugfixes:
 

--- a/src/Web/UIEvent/InputEvent.js
+++ b/src/Web/UIEvent/InputEvent.js
@@ -6,6 +6,6 @@ export function isComposing(e) {
   return e.isComposing;
 }
 
-export function inputType_(e) {
+export function _inputType(e) {
   return e.inputType;
 }

--- a/src/Web/UIEvent/InputEvent.js
+++ b/src/Web/UIEvent/InputEvent.js
@@ -5,3 +5,7 @@ export function data_(e) {
 export function isComposing(e) {
   return e.isComposing;
 }
+
+export function inputType_(e) {
+  return e.inputType;
+}

--- a/src/Web/UIEvent/InputEvent.purs
+++ b/src/Web/UIEvent/InputEvent.purs
@@ -6,7 +6,7 @@ import Data.Maybe (Maybe)
 import Unsafe.Coerce (unsafeCoerce)
 import Web.Event.Event (Event)
 import Web.Internal.FFI (unsafeReadProtoTagged)
-import Web.UIEvent.InputEvent.InputTypes (InputType, toEnumInputType)
+import Web.UIEvent.InputEvent.InputTypes (InputType, parse)
 import Web.UIEvent.UIEvent (UIEvent)
 
 foreign import data InputEvent :: Type
@@ -27,8 +27,8 @@ foreign import data_ :: InputEvent -> String
 
 foreign import isComposing :: InputEvent -> Boolean
 
-foreign import inputType_ :: InputEvent -> String
+foreign import _inputType :: InputEvent -> String
 
-inputType :: InputEvent -> Maybe InputType
-inputType = toEnumInputType <<< inputType_
+inputType :: InputEvent -> InputType
+inputType = parse <<< _inputType
 

--- a/src/Web/UIEvent/InputEvent.purs
+++ b/src/Web/UIEvent/InputEvent.purs
@@ -1,9 +1,12 @@
 module Web.UIEvent.InputEvent where
 
+import Prelude
+
 import Data.Maybe (Maybe)
 import Unsafe.Coerce (unsafeCoerce)
 import Web.Event.Event (Event)
 import Web.Internal.FFI (unsafeReadProtoTagged)
+import Web.UIEvent.InputEvent.InputTypes (InputType, toEnumInputType)
 import Web.UIEvent.UIEvent (UIEvent)
 
 foreign import data InputEvent :: Type
@@ -23,3 +26,9 @@ toEvent = unsafeCoerce
 foreign import data_ :: InputEvent -> String
 
 foreign import isComposing :: InputEvent -> Boolean
+
+foreign import inputType_ :: InputEvent -> String
+
+inputType :: InputEvent -> Maybe InputType
+inputType = toEnumInputType <<< inputType_
+

--- a/src/Web/UIEvent/InputEvent.purs
+++ b/src/Web/UIEvent/InputEvent.purs
@@ -6,7 +6,7 @@ import Data.Maybe (Maybe)
 import Unsafe.Coerce (unsafeCoerce)
 import Web.Event.Event (Event)
 import Web.Internal.FFI (unsafeReadProtoTagged)
-import Web.UIEvent.InputEvent.InputTypes (InputType, parse)
+import Web.UIEvent.InputEvent.InputType (InputType, parse)
 import Web.UIEvent.UIEvent (UIEvent)
 
 foreign import data InputEvent :: Type

--- a/src/Web/UIEvent/InputEvent/InputType.purs
+++ b/src/Web/UIEvent/InputEvent/InputType.purs
@@ -1,4 +1,4 @@
-module Web.UIEvent.InputEvent.InputTypes where
+module Web.UIEvent.InputEvent.InputType where
 
 import Prelude
 

--- a/src/Web/UIEvent/InputEvent/InputTypes.purs
+++ b/src/Web/UIEvent/InputEvent/InputTypes.purs
@@ -1,0 +1,155 @@
+module Web.UIEvent.InputEvent.InputTypes where
+
+import Prelude
+
+import Data.Maybe (Maybe(..))
+
+data InputType
+  = InsertText
+  | InsertReplacementText
+  | InsertLineBreak
+  | InsertParagraph
+  | InsertOrderedList
+  | InsertUnorderedList
+  | InsertHorizontalRule
+  | InsertFromYank
+  | InsertFromDrop
+  | InsertFromPaste
+  | InsertFromPasteAsQuotation
+  | InsertTranspose
+  | InsertCompositionText
+  | InsertLink
+  | DeleteWordBackward
+  | DeleteWordForward
+  | DeleteSoftLineBackward
+  | DeleteSoftLineForward
+  | DeleteEntireSoftLine
+  | DeleteHardLineBackward
+  | DeleteHardLineForward
+  | DeleteByDrag
+  | DeleteByCut
+  | DeleteContent
+  | DeleteContentBackward
+  | DeleteContentForward
+  | HistoryUndo
+  | HistoryRedo
+  | FormatBold
+  | FormatItalic
+  | FormatUnderline
+  | FormatStrikeThrough
+  | FormatSuperscript
+  | FormatSubscript
+  | FormatJustifyFull
+  | FormatJustifyCenter
+  | FormatJustifyRight
+  | FormatJustifyLeft
+  | FormatIndent
+  | FormatOutdent
+  | FormatRemove
+  | FormatSetBlockTextDirection
+  | FormatSetInlineTextDirection
+  | FormatBackColor
+  | FormatFontColor
+  | FormatFontName
+
+derive instance eqInputType :: Eq InputType
+
+instance showInputType :: Show InputType where
+  show = fromEnumInputType
+
+toEnumInputType :: String -> Maybe InputType
+toEnumInputType "insertText" = Just InsertText
+toEnumInputType "insertReplacementText" = Just InsertReplacementText
+toEnumInputType "insertLineBreak" = Just InsertLineBreak
+toEnumInputType "insertParagraph" = Just InsertParagraph
+toEnumInputType "insertOrderedList" = Just InsertOrderedList
+toEnumInputType "insertUnorderedList" = Just InsertUnorderedList
+toEnumInputType "insertHorizontalRule" = Just InsertHorizontalRule
+toEnumInputType "insertFromYank" = Just InsertFromYank
+toEnumInputType "insertFromDrop" = Just InsertFromDrop
+toEnumInputType "insertFromPaste" = Just InsertFromPaste
+toEnumInputType "insertFromPasteAsQuotation" = Just InsertFromPasteAsQuotation
+toEnumInputType "insertTranspose" = Just InsertTranspose
+toEnumInputType "insertCompositionText" = Just InsertCompositionText
+toEnumInputType "insertLink" = Just InsertLink
+toEnumInputType "deleteWordBackward" = Just DeleteWordBackward
+toEnumInputType "deleteWordForward" = Just DeleteWordForward
+toEnumInputType "deleteSoftLineBackward" = Just DeleteSoftLineBackward
+toEnumInputType "deleteSoftLineForward" = Just DeleteSoftLineForward
+toEnumInputType "deleteEntireSoftLine" = Just DeleteEntireSoftLine
+toEnumInputType "deleteHardLineBackward" = Just DeleteHardLineBackward
+toEnumInputType "deleteHardLineForward" = Just DeleteHardLineForward
+toEnumInputType "deleteByDrag" = Just DeleteByDrag
+toEnumInputType "deleteByCut" = Just DeleteByCut
+toEnumInputType "deleteContent" = Just DeleteContent
+toEnumInputType "deleteContentBackward" = Just DeleteContentBackward
+toEnumInputType "deleteContentForward" = Just DeleteContentForward
+toEnumInputType "historyUndo" = Just HistoryUndo
+toEnumInputType "historyRedo" = Just HistoryRedo
+toEnumInputType "formatBold" = Just FormatBold
+toEnumInputType "formatItalic" = Just FormatItalic
+toEnumInputType "formatUnderline" = Just FormatUnderline
+toEnumInputType "formatStrikeThrough" = Just FormatStrikeThrough
+toEnumInputType "formatSuperscript" = Just FormatSuperscript
+toEnumInputType "formatSubscript" = Just FormatSubscript
+toEnumInputType "formatJustifyFull" = Just FormatJustifyFull
+toEnumInputType "formatJustifyCenter" = Just FormatJustifyCenter
+toEnumInputType "formatJustifyRight" = Just FormatJustifyRight
+toEnumInputType "formatJustifyLeft" = Just FormatJustifyLeft
+toEnumInputType "formatIndent" = Just FormatIndent
+toEnumInputType "formatOutdent" = Just FormatOutdent
+toEnumInputType "formatRemove" = Just FormatRemove
+toEnumInputType "formatSetBlockTextDirection" = Just FormatSetBlockTextDirection
+toEnumInputType "formatSetInlineTextDirection" = Just FormatSetInlineTextDirection
+toEnumInputType "formatBackColor" = Just FormatBackColor
+toEnumInputType "formatFontColor" = Just FormatFontColor
+toEnumInputType "formatFontName" = Just FormatFontName
+toEnumInputType _ = Nothing
+
+fromEnumInputType :: InputType -> String
+fromEnumInputType InsertText = "insertText"
+fromEnumInputType InsertReplacementText = "insertReplacementText"
+fromEnumInputType InsertLineBreak = "insertLineBreak"
+fromEnumInputType InsertParagraph = "insertParagraph"
+fromEnumInputType InsertOrderedList = "insertOrderedList"
+fromEnumInputType InsertUnorderedList = "insertUnorderedList"
+fromEnumInputType InsertHorizontalRule = "insertHorizontalRule"
+fromEnumInputType InsertFromYank = "insertFromYank"
+fromEnumInputType InsertFromDrop = "insertFromDrop"
+fromEnumInputType InsertFromPaste = "insertFromPaste"
+fromEnumInputType InsertFromPasteAsQuotation = "insertFromPasteAsQuotation"
+fromEnumInputType InsertTranspose = "insertTranspose"
+fromEnumInputType InsertCompositionText = "insertCompositionText"
+fromEnumInputType InsertLink = "insertLink"
+fromEnumInputType DeleteWordBackward = "deleteWordBackward"
+fromEnumInputType DeleteWordForward = "deleteWordForward"
+fromEnumInputType DeleteSoftLineBackward = "deleteSoftLineBackward"
+fromEnumInputType DeleteSoftLineForward = "deleteSoftLineForward"
+fromEnumInputType DeleteEntireSoftLine = "deleteEntireSoftLine"
+fromEnumInputType DeleteHardLineBackward = "deleteHardLineBackward"
+fromEnumInputType DeleteHardLineForward = "deleteHardLineForward"
+fromEnumInputType DeleteByDrag = "deleteByDrag"
+fromEnumInputType DeleteByCut = "deleteByCut"
+fromEnumInputType DeleteContent = "deleteContent"
+fromEnumInputType DeleteContentBackward = "deleteContentBackward"
+fromEnumInputType DeleteContentForward = "deleteContentForward"
+fromEnumInputType HistoryUndo = "historyUndo"
+fromEnumInputType HistoryRedo = "historyRedo"
+fromEnumInputType FormatBold = "formatBold"
+fromEnumInputType FormatItalic = "formatItalic"
+fromEnumInputType FormatUnderline = "formatUnderline"
+fromEnumInputType FormatStrikeThrough = "formatStrikeThrough"
+fromEnumInputType FormatSuperscript = "formatSuperscript"
+fromEnumInputType FormatSubscript = "formatSubscript"
+fromEnumInputType FormatJustifyFull = "formatJustifyFull"
+fromEnumInputType FormatJustifyCenter = "formatJustifyCenter"
+fromEnumInputType FormatJustifyRight = "formatJustifyRight"
+fromEnumInputType FormatJustifyLeft = "formatJustifyLeft"
+fromEnumInputType FormatIndent = "formatIndent"
+fromEnumInputType FormatOutdent = "formatOutdent"
+fromEnumInputType FormatRemove = "formatRemove"
+fromEnumInputType FormatSetBlockTextDirection = "formatSetBlockTextDirection"
+fromEnumInputType FormatSetInlineTextDirection = "formatSetInlineTextDirection"
+fromEnumInputType FormatBackColor = "formatBackColor"
+fromEnumInputType FormatFontColor = "formatFontColor"
+fromEnumInputType FormatFontName = "formatFontName"

--- a/src/Web/UIEvent/InputEvent/InputTypes.purs
+++ b/src/Web/UIEvent/InputEvent/InputTypes.purs
@@ -2,8 +2,6 @@ module Web.UIEvent.InputEvent.InputTypes where
 
 import Prelude
 
-import Data.Maybe (Maybe(..))
-
 data InputType
   = InsertText
   | InsertReplacementText
@@ -51,105 +49,108 @@ data InputType
   | FormatBackColor
   | FormatFontColor
   | FormatFontName
+  | Other String
 
 derive instance eqInputType :: Eq InputType
+derive instance ordInputType :: Ord InputType
 
 instance showInputType :: Show InputType where
-  show = fromEnumInputType
+  show = print
 
-toEnumInputType :: String -> Maybe InputType
-toEnumInputType "insertText" = Just InsertText
-toEnumInputType "insertReplacementText" = Just InsertReplacementText
-toEnumInputType "insertLineBreak" = Just InsertLineBreak
-toEnumInputType "insertParagraph" = Just InsertParagraph
-toEnumInputType "insertOrderedList" = Just InsertOrderedList
-toEnumInputType "insertUnorderedList" = Just InsertUnorderedList
-toEnumInputType "insertHorizontalRule" = Just InsertHorizontalRule
-toEnumInputType "insertFromYank" = Just InsertFromYank
-toEnumInputType "insertFromDrop" = Just InsertFromDrop
-toEnumInputType "insertFromPaste" = Just InsertFromPaste
-toEnumInputType "insertFromPasteAsQuotation" = Just InsertFromPasteAsQuotation
-toEnumInputType "insertTranspose" = Just InsertTranspose
-toEnumInputType "insertCompositionText" = Just InsertCompositionText
-toEnumInputType "insertLink" = Just InsertLink
-toEnumInputType "deleteWordBackward" = Just DeleteWordBackward
-toEnumInputType "deleteWordForward" = Just DeleteWordForward
-toEnumInputType "deleteSoftLineBackward" = Just DeleteSoftLineBackward
-toEnumInputType "deleteSoftLineForward" = Just DeleteSoftLineForward
-toEnumInputType "deleteEntireSoftLine" = Just DeleteEntireSoftLine
-toEnumInputType "deleteHardLineBackward" = Just DeleteHardLineBackward
-toEnumInputType "deleteHardLineForward" = Just DeleteHardLineForward
-toEnumInputType "deleteByDrag" = Just DeleteByDrag
-toEnumInputType "deleteByCut" = Just DeleteByCut
-toEnumInputType "deleteContent" = Just DeleteContent
-toEnumInputType "deleteContentBackward" = Just DeleteContentBackward
-toEnumInputType "deleteContentForward" = Just DeleteContentForward
-toEnumInputType "historyUndo" = Just HistoryUndo
-toEnumInputType "historyRedo" = Just HistoryRedo
-toEnumInputType "formatBold" = Just FormatBold
-toEnumInputType "formatItalic" = Just FormatItalic
-toEnumInputType "formatUnderline" = Just FormatUnderline
-toEnumInputType "formatStrikeThrough" = Just FormatStrikeThrough
-toEnumInputType "formatSuperscript" = Just FormatSuperscript
-toEnumInputType "formatSubscript" = Just FormatSubscript
-toEnumInputType "formatJustifyFull" = Just FormatJustifyFull
-toEnumInputType "formatJustifyCenter" = Just FormatJustifyCenter
-toEnumInputType "formatJustifyRight" = Just FormatJustifyRight
-toEnumInputType "formatJustifyLeft" = Just FormatJustifyLeft
-toEnumInputType "formatIndent" = Just FormatIndent
-toEnumInputType "formatOutdent" = Just FormatOutdent
-toEnumInputType "formatRemove" = Just FormatRemove
-toEnumInputType "formatSetBlockTextDirection" = Just FormatSetBlockTextDirection
-toEnumInputType "formatSetInlineTextDirection" = Just FormatSetInlineTextDirection
-toEnumInputType "formatBackColor" = Just FormatBackColor
-toEnumInputType "formatFontColor" = Just FormatFontColor
-toEnumInputType "formatFontName" = Just FormatFontName
-toEnumInputType _ = Nothing
+parse :: String -> InputType
+parse "insertText" = InsertText
+parse "insertReplacementText" = InsertReplacementText
+parse "insertLineBreak" = InsertLineBreak
+parse "insertParagraph" = InsertParagraph
+parse "insertOrderedList" = InsertOrderedList
+parse "insertUnorderedList" = InsertUnorderedList
+parse "insertHorizontalRule" = InsertHorizontalRule
+parse "insertFromYank" = InsertFromYank
+parse "insertFromDrop" = InsertFromDrop
+parse "insertFromPaste" = InsertFromPaste
+parse "insertFromPasteAsQuotation" = InsertFromPasteAsQuotation
+parse "insertTranspose" = InsertTranspose
+parse "insertCompositionText" = InsertCompositionText
+parse "insertLink" = InsertLink
+parse "deleteWordBackward" = DeleteWordBackward
+parse "deleteWordForward" = DeleteWordForward
+parse "deleteSoftLineBackward" = DeleteSoftLineBackward
+parse "deleteSoftLineForward" = DeleteSoftLineForward
+parse "deleteEntireSoftLine" = DeleteEntireSoftLine
+parse "deleteHardLineBackward" = DeleteHardLineBackward
+parse "deleteHardLineForward" = DeleteHardLineForward
+parse "deleteByDrag" = DeleteByDrag
+parse "deleteByCut" = DeleteByCut
+parse "deleteContent" = DeleteContent
+parse "deleteContentBackward" = DeleteContentBackward
+parse "deleteContentForward" = DeleteContentForward
+parse "historyUndo" = HistoryUndo
+parse "historyRedo" = HistoryRedo
+parse "formatBold" = FormatBold
+parse "formatItalic" = FormatItalic
+parse "formatUnderline" = FormatUnderline
+parse "formatStrikeThrough" = FormatStrikeThrough
+parse "formatSuperscript" = FormatSuperscript
+parse "formatSubscript" = FormatSubscript
+parse "formatJustifyFull" = FormatJustifyFull
+parse "formatJustifyCenter" = FormatJustifyCenter
+parse "formatJustifyRight" = FormatJustifyRight
+parse "formatJustifyLeft" = FormatJustifyLeft
+parse "formatIndent" = FormatIndent
+parse "formatOutdent" = FormatOutdent
+parse "formatRemove" = FormatRemove
+parse "formatSetBlockTextDirection" = FormatSetBlockTextDirection
+parse "formatSetInlineTextDirection" = FormatSetInlineTextDirection
+parse "formatBackColor" = FormatBackColor
+parse "formatFontColor" = FormatFontColor
+parse "formatFontName" = FormatFontName
+parse s = Other s
 
-fromEnumInputType :: InputType -> String
-fromEnumInputType InsertText = "insertText"
-fromEnumInputType InsertReplacementText = "insertReplacementText"
-fromEnumInputType InsertLineBreak = "insertLineBreak"
-fromEnumInputType InsertParagraph = "insertParagraph"
-fromEnumInputType InsertOrderedList = "insertOrderedList"
-fromEnumInputType InsertUnorderedList = "insertUnorderedList"
-fromEnumInputType InsertHorizontalRule = "insertHorizontalRule"
-fromEnumInputType InsertFromYank = "insertFromYank"
-fromEnumInputType InsertFromDrop = "insertFromDrop"
-fromEnumInputType InsertFromPaste = "insertFromPaste"
-fromEnumInputType InsertFromPasteAsQuotation = "insertFromPasteAsQuotation"
-fromEnumInputType InsertTranspose = "insertTranspose"
-fromEnumInputType InsertCompositionText = "insertCompositionText"
-fromEnumInputType InsertLink = "insertLink"
-fromEnumInputType DeleteWordBackward = "deleteWordBackward"
-fromEnumInputType DeleteWordForward = "deleteWordForward"
-fromEnumInputType DeleteSoftLineBackward = "deleteSoftLineBackward"
-fromEnumInputType DeleteSoftLineForward = "deleteSoftLineForward"
-fromEnumInputType DeleteEntireSoftLine = "deleteEntireSoftLine"
-fromEnumInputType DeleteHardLineBackward = "deleteHardLineBackward"
-fromEnumInputType DeleteHardLineForward = "deleteHardLineForward"
-fromEnumInputType DeleteByDrag = "deleteByDrag"
-fromEnumInputType DeleteByCut = "deleteByCut"
-fromEnumInputType DeleteContent = "deleteContent"
-fromEnumInputType DeleteContentBackward = "deleteContentBackward"
-fromEnumInputType DeleteContentForward = "deleteContentForward"
-fromEnumInputType HistoryUndo = "historyUndo"
-fromEnumInputType HistoryRedo = "historyRedo"
-fromEnumInputType FormatBold = "formatBold"
-fromEnumInputType FormatItalic = "formatItalic"
-fromEnumInputType FormatUnderline = "formatUnderline"
-fromEnumInputType FormatStrikeThrough = "formatStrikeThrough"
-fromEnumInputType FormatSuperscript = "formatSuperscript"
-fromEnumInputType FormatSubscript = "formatSubscript"
-fromEnumInputType FormatJustifyFull = "formatJustifyFull"
-fromEnumInputType FormatJustifyCenter = "formatJustifyCenter"
-fromEnumInputType FormatJustifyRight = "formatJustifyRight"
-fromEnumInputType FormatJustifyLeft = "formatJustifyLeft"
-fromEnumInputType FormatIndent = "formatIndent"
-fromEnumInputType FormatOutdent = "formatOutdent"
-fromEnumInputType FormatRemove = "formatRemove"
-fromEnumInputType FormatSetBlockTextDirection = "formatSetBlockTextDirection"
-fromEnumInputType FormatSetInlineTextDirection = "formatSetInlineTextDirection"
-fromEnumInputType FormatBackColor = "formatBackColor"
-fromEnumInputType FormatFontColor = "formatFontColor"
-fromEnumInputType FormatFontName = "formatFontName"
+print :: InputType -> String
+print InsertText = "insertText"
+print InsertReplacementText = "insertReplacementText"
+print InsertLineBreak = "insertLineBreak"
+print InsertParagraph = "insertParagraph"
+print InsertOrderedList = "insertOrderedList"
+print InsertUnorderedList = "insertUnorderedList"
+print InsertHorizontalRule = "insertHorizontalRule"
+print InsertFromYank = "insertFromYank"
+print InsertFromDrop = "insertFromDrop"
+print InsertFromPaste = "insertFromPaste"
+print InsertFromPasteAsQuotation = "insertFromPasteAsQuotation"
+print InsertTranspose = "insertTranspose"
+print InsertCompositionText = "insertCompositionText"
+print InsertLink = "insertLink"
+print DeleteWordBackward = "deleteWordBackward"
+print DeleteWordForward = "deleteWordForward"
+print DeleteSoftLineBackward = "deleteSoftLineBackward"
+print DeleteSoftLineForward = "deleteSoftLineForward"
+print DeleteEntireSoftLine = "deleteEntireSoftLine"
+print DeleteHardLineBackward = "deleteHardLineBackward"
+print DeleteHardLineForward = "deleteHardLineForward"
+print DeleteByDrag = "deleteByDrag"
+print DeleteByCut = "deleteByCut"
+print DeleteContent = "deleteContent"
+print DeleteContentBackward = "deleteContentBackward"
+print DeleteContentForward = "deleteContentForward"
+print HistoryUndo = "historyUndo"
+print HistoryRedo = "historyRedo"
+print FormatBold = "formatBold"
+print FormatItalic = "formatItalic"
+print FormatUnderline = "formatUnderline"
+print FormatStrikeThrough = "formatStrikeThrough"
+print FormatSuperscript = "formatSuperscript"
+print FormatSubscript = "formatSubscript"
+print FormatJustifyFull = "formatJustifyFull"
+print FormatJustifyCenter = "formatJustifyCenter"
+print FormatJustifyRight = "formatJustifyRight"
+print FormatJustifyLeft = "formatJustifyLeft"
+print FormatIndent = "formatIndent"
+print FormatOutdent = "formatOutdent"
+print FormatRemove = "formatRemove"
+print FormatSetBlockTextDirection = "formatSetBlockTextDirection"
+print FormatSetInlineTextDirection = "formatSetInlineTextDirection"
+print FormatBackColor = "formatBackColor"
+print FormatFontColor = "formatFontColor"
+print FormatFontName = "formatFontName"
+print (Other s) = s


### PR DESCRIPTION
**Description of the change**

Closes #22 

In detail this implements the [inputType](https://w3c.github.io/uievents/#dom-inputevent-inputtype) property of InputEvents. The list of values for the inputType is taken from [here](https://cdn.staticaly.com/gh/w3c/input-events/v1/index.html)

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
