### PR TITLE
Implement retrieving the target element of a mouse event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Breaking changes:
 
 New features:
 
+- Implement retrieving the target element of a mouse event (#24)
+
 Bugfixes:
 
 Other improvements:

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "eslint": "^7.15.0",
     "pulp": "16.0.0-0",
     "purescript-psa": "^0.8.2",
+    "purescript-web-html": ">=1.0.0",
     "rimraf": "^2.6.2"
   }
 }

--- a/src/Web/UIEvent/MouseEvent.js
+++ b/src/Web/UIEvent/MouseEvent.js
@@ -46,6 +46,10 @@ export function _relatedTarget(e) {
   return e.relatedTarget;
 }
 
+export function target(e) {
+  return e.target;
+}
+
 export function buttons(e) {
   return e.buttons;
 }

--- a/src/Web/UIEvent/MouseEvent.purs
+++ b/src/Web/UIEvent/MouseEvent.purs
@@ -16,6 +16,7 @@ module Web.UIEvent.MouseEvent
   , metaKey
   , button
   , relatedTarget
+  , target
   , buttons
   , getModifierState
   ) where
@@ -28,6 +29,7 @@ import Effect (Effect)
 import Unsafe.Coerce (unsafeCoerce)
 import Web.Event.Event (Event)
 import Web.Event.EventTarget (EventTarget)
+import Web.HTML.HTMLElement (HTMLElement)
 import Web.Internal.FFI (unsafeReadProtoTagged)
 import Web.UIEvent.UIEvent (UIEvent)
 
@@ -71,6 +73,8 @@ foreign import _relatedTarget :: MouseEvent -> Nullable EventTarget
 
 relatedTarget :: MouseEvent -> Maybe EventTarget
 relatedTarget = toMaybe <$> _relatedTarget
+
+foreign import target :: MouseEvent -> HTMLElement
 
 foreign import buttons :: MouseEvent -> Int
 


### PR DESCRIPTION
**Description of the change**

When using `onClick` and similar events, a user may want to retrieve the target of the event, for example to compare with other elements in the DOM tree to see if it's directed to the parent or to some child. This is done with `target` event field. So implement it.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
